### PR TITLE
[03] Add ISS green pilot time series data getter

### DIFF
--- a/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
+++ b/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
@@ -59,8 +59,10 @@ iss_ts.tech_category.unique()
 # %% [markdown]
 # Note that some of the technology categories include other tech categories.<br>
 # `'Low carbon heating'` includes:
-# - `'Solar'`
-# - `'District heating'`
+# - `'Heat pumps'`
+# - `'Geothermal energy'` -- filtered out in this analysis as no investment
+# - `'Solar thermal'` -- there is `Solar` and `Solar thermal`, difference?
+# - `'District heating'` -- filtered out in this analysis as no investment
 # - `'Hydrogen heating'`
 # - `'Biomass heating'`
 # - `'Micro CHP'`
@@ -68,8 +70,9 @@ iss_ts.tech_category.unique()
 #
 # `'EEM'` (energy efficiency and management) includes:
 # - `'Insulation & retrofit'`
-# - `'Smart homes'` -- missing individually in this time series data?
-# - `'Smart meters'` -- missing individually in this time series data?
-# - `'Load shifting'` -- missing individually in this time series data?
+# - `'Smart homes'` -- missing individually in this time series data? included in 'Energy management'? Is 'Energy management' included in 'EEM'? It doesn't look like it as 'Energy management' has higher values than 'EEM' in 2007..?
+# - `'Smart meters'` -- missing individually in this time series data? included in 'Energy management'?
+# - `'Demand response'` -- missing individually in this time series data? included in 'Energy management'?
+# - `'Load shifting'` -- missing individually in this time series data? included in 'Energy management'?
 
 # %%

--- a/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
+++ b/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
@@ -42,6 +42,28 @@ iss_ts.columns
 # `tech_category` = technology category e.g 'Heat pumps', 'Batteries'
 
 # %%
+# see tech categories
+iss_ts.tech_category.unique()
+
+# %% [markdown]
+# Note that some of the technology categories include other tech categories.<br>
+# `'Low carbon heating'` includes:
+# - `'Heat pumps'`
+# - `'Geothermal energy'`
+# - `'Solar thermal'`
+# - `'District heating'`
+# - `'Hydrogen heating'`
+# - `'Biomass heating'`
+# - `'Micro CHP'`
+# - `'Heat storage'`
+#
+# `'EEM'` (energy efficiency and management) includes:
+# - `'Insulation & retrofit'`
+# - `'Energy management'` -- this includes companies working on things like smart homes, smart meters, demand response and load shifting
+#
+# Note that some companies in this dataset can belong to more than one technology category.
+
+# %%
 # check for tech categories with no investment
 categories_with_no_investment = find_zero_items(
     df=iss_ts, item_col="tech_category", value_col="investment_raised_total"
@@ -57,24 +79,3 @@ iss_ts = iss_ts.query(f"tech_category != {categories_with_no_investment}").reset
 # %%
 # see remaining tech categories
 iss_ts.tech_category.unique()
-
-# %% [markdown]
-# Note that some of the technology categories include other tech categories.<br>
-# `'Low carbon heating'` includes:
-# - `'Heat pumps'`
-# - `'Geothermal energy'` -- filtered out in this analysis as no investment
-# - `'Solar thermal'` -- there is `Solar` and `Solar thermal`, difference?
-# - `'District heating'` -- filtered out in this analysis as no investment
-# - `'Hydrogen heating'`
-# - `'Biomass heating'`
-# - `'Micro CHP'`
-# - `'Heat storage'`
-#
-# `'EEM'` (energy efficiency and management) includes:
-# - `'Insulation & retrofit'`
-# - `'Smart homes'` -- missing individually in this time series data? included in 'Energy management'? Is 'Energy management' included in 'EEM'? It doesn't look like it as 'Energy management' has higher values than 'EEM' in 2007..?
-# - `'Smart meters'` -- missing individually in this time series data? included in 'Energy management'?
-# - `'Demand response'` -- missing individually in this time series data? included in 'Energy management'?
-# - `'Load shifting'` -- missing individually in this time series data? included in 'Energy management'?
-
-# %%

--- a/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
+++ b/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
@@ -14,6 +14,9 @@
 #     name: python3
 # ---
 
+# %% [markdown]
+# ## Exploring the relationship between research funding and private investment
+
 # %%
 from iss_forecasting.getters.iss_green_pilot_ts import get_iss_green_pilot_time_series
 from iss_forecasting.utils.processing import find_zero_items

--- a/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
+++ b/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
@@ -50,7 +50,9 @@ categories_with_no_investment
 
 # %%
 # remove tech categories with no investment from time series data
-iss_ts = iss_ts.query(f"tech_category != {categories_with_no_investment}").reset_index()
+iss_ts = iss_ts.query(f"tech_category != {categories_with_no_investment}").reset_index(
+    drop=True
+)
 
 # %%
 # see remaining tech categories

--- a/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
+++ b/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
@@ -1,0 +1,72 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.13.6
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %%
+from iss_forecasting.getters.iss_green_pilot_ts import get_iss_green_pilot_time_series
+from iss_forecasting.utils.processing import find_zero_items
+
+# %%
+# load iss green time series data
+iss_ts = get_iss_green_pilot_time_series()
+
+# %%
+# view column headings
+iss_ts.columns
+
+# %% [markdown]
+# Column descriptions:<br>
+# `year` = year (between 2007 and 2021)<br>
+# `research_no_of_projects` = number of research projects started in a specific `year` (GtR)<br>
+# `research_funding_total` = research funding amount (GBP 1000s) awarded in a specific `year` (GtR)<br>
+# `investment_rounds` = number of rounds of invesmtnet in a specific `year` (Crunchbase)<br>
+# `investment_raised_total` = raised investment amount (GBP 1000s) a specific `year` (Crunchbase)<br>
+# `no_of_orgs_founded` = number of new companies started in the `year` (Crunchbase)<br>
+# `articles` = number of articles in the Guardian with the technology keywords and phrases<br>
+# `speeches` = number of speeches in Hansard with the technology keywords and phrases<br>
+# `tech_category` = technology category e.g 'Heat pumps', 'Batteries'
+
+# %%
+# check for tech categories with no investment
+categories_with_no_investment = find_zero_items(
+    df=iss_ts, item_col="tech_category", value_col="investment_raised_total"
+)
+categories_with_no_investment
+
+# %%
+# remove tech categories with no investment from time series data
+iss_ts = iss_ts.query(f"tech_category != {categories_with_no_investment}").reset_index()
+
+# %%
+# see remaining tech categories
+iss_ts.tech_category.unique()
+
+# %% [markdown]
+# Note that some of the technology categories include other tech categories.<br>
+# `'Low carbon heating'` includes:
+# - `'Solar'`
+# - `'District heating'`
+# - `'Hydrogen heating'`
+# - `'Biomass heating'`
+# - `'Micro CHP'`
+# - `'Heat storage'`
+#
+# `'EEM'` (energy efficiency and management) includes:
+# - `'Insulation & retrofit'`
+# - `'Smart homes'` -- missing individually in this time series data?
+# - `'Smart meters'` -- missing individually in this time series data?
+# - `'Load shifting'` -- missing individually in this time series data?
+
+# %%

--- a/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
+++ b/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
@@ -16,6 +16,7 @@
 
 # %% [markdown]
 # ## Exploring the relationship between research funding and private investment
+# This notebook looks at the relationship between research funding and private investment. It uses pilot data produced from [Innovation Sweet Spots](https://github.com/nestauk/innovation_sweet_spots) that focuses on companies in technology sectors that could help tackle climate change. The underlying research funding data comes from UKRI's Gateway to Research and private investment data comes from Crunchbase.
 
 # %%
 from iss_forecasting.getters.iss_green_pilot_ts import get_iss_green_pilot_time_series
@@ -26,8 +27,8 @@ from iss_forecasting.utils.processing import find_zero_items
 iss_ts = get_iss_green_pilot_time_series()
 
 # %%
-# view column headings
-iss_ts.columns
+# view sample of dataframe
+iss_ts.tail(5)
 
 # %% [markdown]
 # Column descriptions:<br>

--- a/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
+++ b/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
@@ -35,8 +35,8 @@ iss_ts.tail(5)
 # `year` = year (between 2007 and 2021)<br>
 # `research_no_of_projects` = number of research projects started in a specific `year` (GtR)<br>
 # `research_funding_total` = research funding amount (GBP 1000s) awarded in a specific `year` (GtR)<br>
-# `investment_rounds` = number of rounds of invesmtnet in a specific `year` (Crunchbase)<br>
-# `investment_raised_total` = raised investment amount (GBP 1000s) a specific `year` (Crunchbase)<br>
+# `investment_rounds` = number of rounds of investment in a specific `year` (Crunchbase)<br>
+# `investment_raised_total` = raised investment amount (GBP 1000s) in a specific `year` (Crunchbase)<br>
 # `no_of_orgs_founded` = number of new companies started in the `year` (Crunchbase)<br>
 # `articles` = number of articles in the Guardian with the technology keywords and phrases<br>
 # `speeches` = number of speeches in Hansard with the technology keywords and phrases<br>

--- a/iss_forecasting/getters/iss_green_pilot_ts.py
+++ b/iss_forecasting/getters/iss_green_pilot_ts.py
@@ -1,0 +1,19 @@
+"""Data getters for the ISS green pilot time series data.
+Data source: https://github.com/nestauk/innovation_sweet_spots
+"""
+import pandas as pd
+from iss_forecasting import PROJECT_DIR
+
+
+def get_iss_green_pilot_time_series() -> pd.DataFrame:
+    """Load ISS green pilot time series data,
+    rename columns to more be more descriptive
+    """
+    return pd.read_csv(PROJECT_DIR / "inputs/data/ISS_pilot_Time_series.csv").rename(
+        columns={
+            "no_of_projects": "research_no_of_projects",
+            "amount_total": "research_funding_total",
+            "raised_amount_gbp_total": "investment_raised_total",
+            "no_of_rounds": "investment_rounds",
+        }
+    )

--- a/iss_forecasting/utils/processing.py
+++ b/iss_forecasting/utils/processing.py
@@ -1,0 +1,21 @@
+"""Processing utils
+"""
+
+
+def find_zero_items(df, item_col, value_col):
+    """Returns a list of items with 0s for all records in a
+    specified value column
+
+    Args:
+        df (df): dataframe to find items with 0 values
+        item_col (str): column with item names
+        value_col (str): column with value to check for 0s
+
+    Returns:
+        list: list of items with 0s for all records in a specified value column
+    """
+    return [
+        item
+        for item in df[item_col].unique()
+        if df.query(f"{item_col} == '{item}'")[value_col].sum() == 0
+    ]


### PR DESCRIPTION
Closes #3.

This PR adds:
- Data getter to load ISS green pilot time series data (`iss_forecasting/getters/iss_green_pilot_ts.py`)
- Processing function to find items in a dataframe with 0s (`utils/processing.py`)
- Notebook file (`analysis/tech_category_level/research_funding_and_investment.py`) which uses above functions and provides some info about the data and the tech categories. This notebook will be used for further analysis.