### PR TITLE
[07] Add granger causality tests

### DIFF
--- a/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
+++ b/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
@@ -21,8 +21,10 @@
 from iss_forecasting.getters.iss_green_pilot_ts import get_iss_green_pilot_time_series
 from iss_forecasting.utils.processing import find_zero_items
 from iss_forecasting.analysis.utils.plotting import plot_two_y_one_x, lagplot, plot_lags
+from iss_forecasting.utils.stats_tests import stationarity_adf, stationarity_kpss
 import altair as alt
 import pandas as pd
+from statsmodels.tsa.stattools import ccf
 
 # %%
 # load iss green time series data
@@ -113,5 +115,20 @@ for tech_cat in iss_ts.tech_category.unique():
 # %% [markdown]
 # Looking at the above lag plots, there does not seem to be a common time lag between research funding and private investment.<br>
 # The Batteries technology category has the highest correlation values with high correlation between private investment and research funding lagged by 4 years+.
+
+# %%
+for tech_cat in iss_ts.tech_category.unique():
+    tech_cat_df = iss_ts.query(f"tech_category == '{tech_cat}'")
+    stationarity_adf(tech_cat_df.research_funding_total, tech_cat + " research funding")
+    stationarity_kpss(
+        tech_cat_df.research_funding_total, tech_cat + " research funding"
+    )
+    stationarity_adf(tech_cat_df.investment_raised_total, tech_cat + " investment")
+    stationarity_kpss(tech_cat_df.investment_raised_total, tech_cat + " investment")
+    print("*" * 10)
+
+# %%
+
+# %%
 
 # %%

--- a/iss_forecasting/utils/stats_tests.py
+++ b/iss_forecasting/utils/stats_tests.py
@@ -1,27 +1,40 @@
 """Statistical testing utils
 """
 from statsmodels.tsa.stattools import adfuller, kpss
+from numpy.typing import ArrayLike
 
 
-def stationarity_adf(time_series, name):
-    "Check if the time series is stationary based on ADF test"
+def stationarity_adf(time_series: ArrayLike, name: str) -> None:
+    """Check if a time series is stationary based on ADF test
+    and print the results
+
+    Args:
+        time_series: Time series to be checked
+        name: Name of time series
+    """
     results = adfuller(time_series)
     p_value = round(results[1], 3)
     n_lags = results[2]
     print(
         f"{name} ADF test: p_value is {p_value}. {p_value}"
-        f'{" < 0.05, time series is" if p_value < 0.05 else " > 0.05, time series is not"}'
+        f"{' < 0.05, time series is' if p_value < 0.05 else ' > 0.05, time series is not'}"
         f" stationary. {n_lags} lags"
     )
 
 
-def stationarity_kpss(time_series, name):
-    "Check if the time series is stationary based on KPSS test"
+def stationarity_kpss(time_series: ArrayLike, name: str) -> None:
+    """Check if a time series is stationary based on KPSS test
+    and print the results
+
+    Args:
+        time_series: Time series to be checked
+        name: Name of time series
+    """
     results = kpss(time_series)
     p_value = round(results[1], 3)
     n_lags = results[2]
     print(
         f"{name} KPSS test: p_value is {p_value}. {p_value}"
-        f'{" < 0.05, time series is not" if p_value < 0.05 else " > 0.05, time series is"}'
+        f"{' < 0.05, time series is not' if p_value < 0.05 else ' > 0.05, time series is'}"
         f" stationary. {n_lags} lags"
     )

--- a/iss_forecasting/utils/stats_tests.py
+++ b/iss_forecasting/utils/stats_tests.py
@@ -9,7 +9,7 @@ def stationarity_adf(time_series: ArrayLike, name: str) -> None:
     and print the results
 
     Args:
-        time_series: Time series to be checked
+        time_series: Time series to be checked (must be 1 dimensional)
         name: Name of time series
     """
     results = adfuller(time_series)
@@ -27,7 +27,7 @@ def stationarity_kpss(time_series: ArrayLike, name: str) -> None:
     and print the results
 
     Args:
-        time_series: Time series to be checked
+        time_series: Time series to be checked (must be 1 dimensional)
         name: Name of time series
     """
     results = kpss(time_series)

--- a/iss_forecasting/utils/stats_tests.py
+++ b/iss_forecasting/utils/stats_tests.py
@@ -1,0 +1,27 @@
+"""Statistical testing utils
+"""
+from statsmodels.tsa.stattools import adfuller, kpss
+
+
+def stationarity_adf(time_series, name):
+    "Check if the time series is stationary based on ADF test"
+    results = adfuller(time_series)
+    p_value = round(results[1], 3)
+    n_lags = results[2]
+    print(
+        f"{name} ADF test: p_value is {p_value}. {p_value}"
+        f'{" < 0.05, time series is" if p_value < 0.05 else " > 0.05, time series is not"}'
+        f" stationary. {n_lags} lags"
+    )
+
+
+def stationarity_kpss(time_series, name):
+    "Check if the time series is stationary based on KPSS test"
+    results = kpss(time_series)
+    p_value = round(results[1], 3)
+    n_lags = results[2]
+    print(
+        f"{name} KPSS test: p_value is {p_value}. {p_value}"
+        f'{" < 0.05, time series is not" if p_value < 0.05 else " > 0.05, time series is"}'
+        f" stationary. {n_lags} lags"
+    )


### PR DESCRIPTION
Closes #7. 

This PR adds:
* functions to test for stationarity (`iss_forecasting/utils/stats_tests.py`)
* process for testing for granger causality into `iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py` notebook using the Batteries technology category as an example