### PR TITLE
[09] Add confidence intervals to cross correlation lag plots

### DIFF
--- a/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
+++ b/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
@@ -120,13 +120,14 @@ for tech_cat in iss_ts.tech_category.unique():
         x=iss_ts_current_tc.research_funding_total,
         title=tech_cat,
         y=iss_ts_current_tc.investment_raised_total,
-        lags=8,
-        nrows=1,
+        lags=9,
+        nrows=2,
     )
 
 # %% [markdown]
 # Looking at the above lag plots, there does not seem to be a common time lag between research funding and private investment.<br>
-# The Batteries technology category has the highest correlation values with high correlation between private investment and research funding lagged by 4 years+.
+# The Batteries technology category has the highest correlation values with high correlation between private investment and research funding lagged by 4 years+.<br>
+# The confidence intervals are quite wide across the plots. The Batteries technology category has a reasonable confidence interval when lagged by 4 years+.
 
 # %% [markdown]
 # # Granger Causality
@@ -210,5 +211,3 @@ pi_predict_rf = grangercausalitytests(
 
 # %% [markdown]
 # At this stage, I don't think we can draw too much from this but this process can be rerun when we have the data at split at smaller time intervals.
-
-# %%

--- a/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
+++ b/iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py
@@ -126,8 +126,15 @@ for tech_cat in iss_ts.tech_category.unique():
 
 # %% [markdown]
 # Looking at the above lag plots, there does not seem to be a common time lag between research funding and private investment.<br>
-# The Batteries technology category has the highest correlation values with high correlation between private investment and research funding lagged by 4 years+.<br>
-# The confidence intervals are quite wide across the plots. The Batteries technology category has a reasonable confidence interval when lagged by 4 years+.
+# `Micro CHP`,`Solar thermal`, `Insulation & retrofit`, `Solar`, `Wind & offshore`, `Hydrogen & fuel cells`, `Bioenergy`, `Carbon capture & storage`  -- there are no significant correlations at any lag.<br>
+# `Heat Storage` -- there are correlations at lags 0, 2, and 4. <br>
+# `Heat Pumps` -- there is correlation at lag 3.<br>
+# `Hydrogen heating` -- there is correlation at lag 2.<br>
+# `Biomass heating` -- there is correlation at lag 1.<br>
+# `Energy management` -- there is correlation at lag 4 and lag 6.<br>
+# `Low carbon heating` -- there is correlation at lag 0 and negative correlation at lag 4 and lag 9.<br>
+# `EEM` -- there is correlation at lags 4 and 6.<br>
+# `Batteries` -- the correlations are significant at all lags, with strong correlations from lags 1 and higher.<br>
 
 # %% [markdown]
 # # Granger Causality

--- a/iss_forecasting/analysis/utils/plotting.py
+++ b/iss_forecasting/analysis/utils/plotting.py
@@ -7,6 +7,7 @@ import pandas as pd
 from matplotlib.offsetbox import AnchoredText
 from altair.vegalite.v4.api import LayerChart
 import seaborn as sns
+import pingouin as pg
 import math
 
 # Set Matplotlib defaults
@@ -89,7 +90,9 @@ def lagplot(
     """
     x_ = x.shift(lag)
     y_ = y if y is not None else x
-    corr = y_.corr(x_)
+    pg_corr = pg.corr(x_, y_).round(2)
+    r = pg_corr["r"].values[0]
+    ci = pg_corr["CI95%"].values[0]
     if ax is None:
         _, ax = plt.subplots()
     scatter_kws = dict(
@@ -110,8 +113,8 @@ def lagplot(
         ax=ax,
     )
     at = AnchoredText(
-        f"{corr:.2f}",
-        prop=dict(size="medium"),
+        f"r:{r}, ci:{ci}",
+        prop=dict(size=8.5, fontweight="bold"),
         frameon=True,
         loc="upper right",
     )

--- a/iss_forecasting/analysis/utils/plotting.py
+++ b/iss_forecasting/analysis/utils/plotting.py
@@ -90,7 +90,7 @@ def lagplot(
     """
     x_ = x.shift(lag)
     y_ = y if y is not None else x
-    pg_corr = pg.corr(x_, y_).round(2)
+    pg_corr = pg.corr(x_, y_, method="spearman").round(2)
     r = pg_corr["r"].values[0]
     ci = pg_corr["CI95%"].values[0]
     if ax is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sh==1.14.2
 statsmodels==0.13.1
 seaborn==0.11.2
 scikit-learn==1.0.2
+pingouin==0.5.0


### PR DESCRIPTION
Closes #9.

 This PR:
* Adds confidence intervals into the `lagplot` function at `iss_forecasting/analysis/utils/plotting.py`
* Adds updated cross correlation lagplots into  notebook at `iss_forecasting/analysis/tech_category_level/research_funding_and_investment.py` and adds a note on the confidence intervals of the plots